### PR TITLE
Small fix to create link for all short strings representing periods (wee...

### DIFF
--- a/phpreport-report
+++ b/phpreport-report
@@ -349,8 +349,9 @@ class TwikiUploader(object):
     def add_links_for_short_strings(self, contents, time_periods):
         for time_period in time_periods:
             short_string = time_period.short_string()
-            contents = contents.replace("%s " % short_string,
-                                        "[[%s][%s]] " % (time_period.wiki_string(), short_string))
+            contents = re.sub("%s([^a-zA-Z0-9])" % short_string,
+                              "[[%s][%s]]\g<1>" % (time_period.wiki_string(), short_string),
+                              contents)
         return contents
 
     def upload(self, reports, time_periods):


### PR DESCRIPTION
...ks) in the report

This will create a link for each week in the summary table.
