### PR TITLE
Add extra space to separate task description and story fields

### DIFF
--- a/phpreport-report
+++ b/phpreport-report
@@ -215,7 +215,7 @@ class DetailedReport(object):
 
     def get_stories_for_day_and_user(self, user, date):
         tasks_for_day = self.time_period.filter_tasks(date=date, user=user)
-        all_stories = " ".join([task.text + task.story for task in tasks_for_day])
+        all_stories = " ".join([task.text + " " + task.story for task in tasks_for_day])
 
         # Strip out duplicated whitespace
         return re.compile(r'\s+').sub(' ', all_stories).strip()


### PR DESCRIPTION
In the case you use the story field in PhpReport the output is better using a space:
- My task description.ItEr01S01MyStory
  vs:
- My task description. ItEr01S01MyStory

Moreover this will create a link if the Story field is a TWiki name, which is a very usual use case.
