### PR TITLE
Add support for 2FA TOTP code

### DIFF
--- a/phpreport.py
+++ b/phpreport.py
@@ -318,8 +318,13 @@ class PHPReport:
             sys.exit(1)
 
     @classmethod
-    def send_login_request(cls, address, username, password):
+    def send_login_request(cls, address, username, password, totp):
         url = f"{address}/loginService.php"
+        if totp:
+            query_params = {'totp': totp}
+            encoded_params = urllib.parse.urlencode(query_params)
+            url = f"{address}/loginService.php?{encoded_params}"
+
         request = urllib.request.Request(url, None)
         auth_string = bytes(f"{username}:{password}", "UTF-8")
         request.add_header("Authorization", f"Basic {base64.b64encode(auth_string)}")
@@ -335,9 +340,11 @@ class PHPReport:
         cls.credential = Credential.for_url(address, username)
         cls.credential.activate()
 
+        totp = getpass.getpass("2FA One-time Code (leave blank if you don't have 2FA enabled for your account): ")
+
         print("Logging in...")
         response = cls.send_login_request(
-            cls.address, cls.credential.username, cls.credential.password
+            cls.address, cls.credential.username, cls.credential.password, totp
         )
 
         cls.session_id = None

--- a/phpreport.py
+++ b/phpreport.py
@@ -320,11 +320,16 @@ class PHPReport:
     @classmethod
     def send_login_request(cls, address, username, password, totp):
         url = f"{address}/loginService.php"
-        if totp:
-            query_params = {'totp': totp}
-            encoded_params = urllib.parse.urlencode(query_params)
-            url = f"{address}/loginService.php?{encoded_params}"
 
+        query_params = {}
+        if totp:
+            query_params['totp'] = totp
+
+        if query_params:
+            encoded_params = urllib.parse.urlencode(query_params)
+            url += f"?{encoded_params}"
+
+        print(url)
         request = urllib.request.Request(url, None)
         auth_string = bytes(f"{username}:{password}", "UTF-8")
         request.add_header("Authorization", f"Basic {base64.b64encode(auth_string)}")
@@ -340,7 +345,7 @@ class PHPReport:
         cls.credential = Credential.for_url(address, username)
         cls.credential.activate()
 
-        totp = getpass.getpass("2FA One-time Code (leave blank if you don't have 2FA enabled for your account): ")
+        totp = getpass.getpass("6-digit verification code (leave blank if 2FA disabled): ")
 
         print("Logging in...")
         response = cls.send_login_request(


### PR DESCRIPTION
If the user has 2FA enabled, they need to pass along with the credentials a 2FA code from their chosen Time-based one-time (TOTP) application. In case they don't have it setup, they can just leave it blank and it will try to authenticate without it.

This code is not stored in the keyring because it is meant to be disposable and expires fast.